### PR TITLE
Allow to provide configuration object or file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ Default: `stylish`
 
 Custom error formatter or the name of a built-in formatter.
 
+### configuration
+
+Type: `object` or `string`
+Default: `null`
+
+Full configuration can be provided either as a path to a `tsconfig.json` or a configuration object.
+
 
 # License
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ export default function tslint (options = {}) {
         options.configuration === undefined ||
         isString(options.configuration))
         ? Configuration.findConfiguration(options.configuration || null, fileName).results
-        : options.configuration
+        : Configuration.parseConfigFile(options.configuration, process.cwd())
 
       const fileContents = fs.readFileSync(fileName, 'utf8')
 

--- a/test/alternative-tsconfig.json
+++ b/test/alternative-tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "rules": {
+        "indent": {
+            "options": ["tabs"]
+        }   
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -76,4 +76,41 @@ describe('rollup-plugin-tslint', () => {
 			assert.equal(result.ruleName, 'restrict-plus-operands');
 		});
 	});
+
+	it('should be able to take an alternative configuration file', () => {
+		let result = {};
+		return rollup({
+			entry: 'fixtures/typechecking.ts',
+			plugins: [
+				tslint({ formatter: createFormatter(result), configuration: "alternative-tsconfig.json" })
+			]
+		}).then(() => {
+			assert.equal(result.count, 1);
+			assert.equal(result.failure, 'tab indentation expected');
+			assert.equal(result.ruleName, 'indent');
+		});
+	});
+
+	it('should be able to take an inline configuration', () => {
+		let result = {};
+		return rollup({
+			entry: 'fixtures/typechecking.ts',
+			plugins: [
+				tslint({ 
+					formatter: createFormatter(result), 
+					configuration: {
+						rules: {
+							indent: {
+								options: ["tabs"]
+							}   
+						}
+					} 
+				})
+			]
+		}).then(() => {
+			assert.equal(result.count, 1);
+			assert.equal(result.failure, 'tab indentation expected');
+			assert.equal(result.ruleName, 'indent');
+		});
+	});
 });


### PR DESCRIPTION
Hi,

I made a change to allow to provide a configuration file or configuration object.

This allows to customize the configuration without a `tsconfig.json`